### PR TITLE
Fix up counter script

### DIFF
--- a/MyDocuments/Scripts/count_to_100.sh
+++ b/MyDocuments/Scripts/count_to_100.sh
@@ -5,7 +5,7 @@ do
   then
     echo I have counted to $i
   else 
-    echo You should have used ended the script by now! I have counted to $i! 
+    echo You should have used Ctrl+C to end the script by now! I have counted to $i! 
   fi
   sleep 0.2s
 done


### PR DESCRIPTION
* Make it executable
* Fix typo in message

Instead of making it executable, we could change the README to tell
people to run:
```console
$ bash ./count_to_100.sh
```

instead of
```console
$ ./count_to_100.sh
```

which is more like how they'll run things with `node`...